### PR TITLE
Fix emotion update delegate for UE 5.6

### DIFF
--- a/UnrealIntegration/NovaLink/Source/NovaLink/Private/EmotionReceiver.cpp
+++ b/UnrealIntegration/NovaLink/Source/NovaLink/Private/EmotionReceiver.cpp
@@ -93,7 +93,7 @@ void UEmotionReceiver::HandleMessage(const FString& Message)
     TMap<FString, float> ParsedValues;
     if (TryParseEmotionMessage(Message, ParsedValues))
     {
-        OnEmotionUpdate.Broadcast(ParsedValues);
+        OnEmotionUpdate.Broadcast(FNovaLinkEmotionData(ParsedValues));
     }
     else
     {

--- a/UnrealIntegration/NovaLink/Source/NovaLink/Public/EmotionReceiver.h
+++ b/UnrealIntegration/NovaLink/Source/NovaLink/Public/EmotionReceiver.h
@@ -5,7 +5,23 @@
 
 class IWebSocket;
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FNovaLinkEmotionUpdate, const TMap<FString, float>&, EmotionValues);
+USTRUCT(BlueprintType)
+struct NOVALINK_API FNovaLinkEmotionData
+{
+    GENERATED_BODY()
+
+    FNovaLinkEmotionData() = default;
+
+    explicit FNovaLinkEmotionData(const TMap<FString, float>& InValues)
+        : EmotionValues(InValues)
+    {
+    }
+
+    UPROPERTY(BlueprintReadWrite, Category = "NovaLink|Emotion")
+    TMap<FString, float> EmotionValues;
+};
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FNovaLinkEmotionUpdate, const FNovaLinkEmotionData&, EmotionData);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FNovaLinkEmotionConnectionStateChanged, bool, bIsConnected);
 
 UCLASS(BlueprintType)


### PR DESCRIPTION
## Summary
- wrap the emotion payload map in a BlueprintType FNovaLinkEmotionData struct so UHT can process it
- update the NovaLink emotion update delegate and broadcast site to use FNovaLinkEmotionData

## Testing
- not run (Unreal Engine build tooling is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e47e672488832f9e10fd598530da24