### PR TITLE
Add WebSockets dependency to NovaLink build rules

### DIFF
--- a/UnrealIntegration/NovaLink/Source/NovaLink/NovaLink.Build.cs
+++ b/UnrealIntegration/NovaLink/Source/NovaLink/NovaLink.Build.cs
@@ -15,7 +15,8 @@ public class NovaLink : ModuleRules
             "Json",
             "JsonUtilities",
             "Networking",
-            "Sockets"
+            "Sockets",
+            "WebSockets"
         });
 
         PrivateDependencyModuleNames.AddRange(new[]


### PR DESCRIPTION
## Summary
- include the WebSockets module in NovaLink's public dependencies to allow WebSocket headers to compile

## Testing
- not run (Unreal Build Tool not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e481ecfe1c832f989d95a06af22731