### PR TITLE
Run streaming server in background thread and harden shutdown

### DIFF
--- a/Interface/control_panel.py
+++ b/Interface/control_panel.py
@@ -27,6 +27,7 @@ class BackendWorker(QtCore.QThread):
         self.config = config
         self.loop: Optional[asyncio.AbstractEventLoop] = None
         self.orchestrator: Optional[VoiceAgentOrchestrator] = None
+        self._shutting_down = False
 
     def run(self) -> None:  # type: ignore[override]
         try:
@@ -60,15 +61,27 @@ class BackendWorker(QtCore.QThread):
         asyncio.run_coroutine_threadsafe(_task(), self.loop)
 
     def shutdown(self) -> None:
+        if self._shutting_down:
+            return
         if not self.loop or not self.orchestrator:
             return
 
+        self._shutting_down = True
+
         async def _shutdown() -> None:
-            await self.orchestrator.stop()
-            self.loop.stop()
+            if self.orchestrator:
+                await self.orchestrator.stop()
+                self.orchestrator = None
+            if self.loop:
+                self.loop.stop()
 
         future = asyncio.run_coroutine_threadsafe(_shutdown(), self.loop)
-        future.result()
+        try:
+            future.result(timeout=10)
+        except Exception as exc:  # pragma: no cover - GUI path
+            logger.exception("Backend shutdown failed: %s", exc)
+        finally:
+            self._shutting_down = False
 
 
 class ControlPanel(QtWidgets.QMainWindow):
@@ -81,6 +94,7 @@ class ControlPanel(QtWidgets.QMainWindow):
 
         self.config = load_orchestrator_config(config_path)
         self.backend: Optional[BackendWorker] = None
+        self._closing = False
         self._create_backend()
 
         self._setup_ui()
@@ -201,10 +215,21 @@ class ControlPanel(QtWidgets.QMainWindow):
         self.log_view.appendPlainText(message)
 
     def closeEvent(self, event: QtGui.QCloseEvent) -> None:  # type: ignore[override]
+        if self._closing:
+            super().closeEvent(event)
+            return
+
+        self._closing = True
+        self.start_button.setEnabled(False)
+        self.stop_button.setEnabled(False)
+        self.send_button.setEnabled(False)
+        self.input_box.setEnabled(False)
+
         try:
             if self.backend:
                 self.backend.shutdown()
-                self.backend.wait(2000)
+                # Wait until the backend thread exits so the streaming server stops cleanly.
+                self.backend.wait(5000)
                 self.backend = None
         finally:
             super().closeEvent(event)

--- a/Utils/orchestrator.py
+++ b/Utils/orchestrator.py
@@ -2,13 +2,12 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
 from LLM.engine import LLMConfig, LLMEngine
-from Server.streaming import StreamConfig, StreamServer, serve
+from Server.streaming import StreamConfig, StreamServer, StreamingServer
 from TTS.kani_engine import KaniTTSConfig, KaniTTSEngine
 from Utils.emotions import EmotionMapper
 
@@ -31,15 +30,22 @@ class VoiceAgentOrchestrator:
         self.tts = KaniTTSEngine(config.tts)
         self.stream_server = StreamServer(config.stream)
         self._emotion_mapper = EmotionMapper()
-        self._server_task: Optional[asyncio.Task] = None
+        self._streaming_server = StreamingServer(
+            self.stream_server.app,
+            config.stream.host,
+            config.stream.port,
+        )
+        self._started = False
 
     async def start(self) -> None:
+        if self._started:
+            logger.debug("Orchestrator already started")
+            return
         logger.info("Starting orchestrator")
         self.llm.load()
         await self.tts.load()
-        self._server_task = asyncio.create_task(
-            serve(self.stream_server.app, self.config.stream.host, self.config.stream.port)
-        )
+        self._streaming_server.start()
+        self._started = True
         logger.info(
             "Stream server running on ws://%s:%s%s",
             self.config.stream.host,
@@ -48,10 +54,10 @@ class VoiceAgentOrchestrator:
         )
 
     async def stop(self) -> None:
-        if self._server_task:
-            self._server_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._server_task
+        if not self._started:
+            return
+        await asyncio.to_thread(self._streaming_server.stop)
+        self._started = False
         logger.info("Orchestrator stopped")
 
     async def process_text(self, user_message: str, chat_history: Optional[List[Dict[str, str]]] = None) -> Dict[str, str]:


### PR DESCRIPTION
## Summary
- replace the coroutine-based uvicorn launcher with a reusable StreamingServer helper
- update the orchestrator to manage the background streaming server lifecycle
- make the Qt backend shutdown and window close paths robust against repeated stops

## Testing
- python -m compileall Server Utils Interface

------
https://chatgpt.com/codex/tasks/task_e_68e49fa72668832f89b546443dfdffac