### PR TITLE
Add WebSocket client status reporting and improve TTS startup errors

### DIFF
--- a/Server/streaming.py
+++ b/Server/streaming.py
@@ -5,7 +5,7 @@ import asyncio
 import json
 import logging
 from dataclasses import dataclass
-from typing import Dict, Set
+from typing import Callable, Dict, Optional, Set
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
@@ -51,7 +51,13 @@ class BroadcastQueue:
 class StreamServer:
     """FastAPI application bundling the audio and emotion streaming endpoints."""
 
-    def __init__(self, config: StreamConfig):
+    def __init__(
+        self,
+        config: StreamConfig,
+        *,
+        on_audio_client_count_changed: Optional[Callable[[int], None]] = None,
+        on_emotion_client_count_changed: Optional[Callable[[int], None]] = None,
+    ):
         self.config = config
         self.app = FastAPI(title="Unreal Voice Agent Stream Server")
         self.app.add_middleware(
@@ -64,6 +70,11 @@ class StreamServer:
         self.audio_broadcast = BroadcastQueue()
         self.emotion_broadcast = BroadcastQueue()
 
+        self._audio_client_count = 0
+        self._emotion_client_count = 0
+        self._on_audio_client_count_changed = on_audio_client_count_changed
+        self._on_emotion_client_count_changed = on_emotion_client_count_changed
+
         self.app.websocket(self.config.audio_endpoint)(self._audio_handler)
         self.app.websocket(self.config.emotion_endpoint)(self._emotion_handler)
 
@@ -71,6 +82,8 @@ class StreamServer:
         await websocket.accept()
         listener_queue = await self.audio_broadcast.register()
         logger.info("Audio client connected: %s", websocket.client)
+        self._audio_client_count += 1
+        self._emit_audio_client_count()
         try:
             while True:
                 chunk = await listener_queue.get()
@@ -79,11 +92,15 @@ class StreamServer:
             logger.info("Audio client disconnected: %s", websocket.client)
         finally:
             await self.audio_broadcast.unregister(listener_queue)
+            self._audio_client_count = max(0, self._audio_client_count - 1)
+            self._emit_audio_client_count()
 
     async def _emotion_handler(self, websocket: WebSocket) -> None:
         await websocket.accept()
         listener_queue = await self.emotion_broadcast.register()
         logger.info("Emotion client connected: %s", websocket.client)
+        self._emotion_client_count += 1
+        self._emit_emotion_client_count()
         try:
             while True:
                 payload = await listener_queue.get()
@@ -92,6 +109,8 @@ class StreamServer:
             logger.info("Emotion client disconnected: %s", websocket.client)
         finally:
             await self.emotion_broadcast.unregister(listener_queue)
+            self._emotion_client_count = max(0, self._emotion_client_count - 1)
+            self._emit_emotion_client_count()
 
     async def push_audio(self, chunk: bytes) -> None:
         await self.audio_broadcast.broadcast(chunk)
@@ -99,6 +118,20 @@ class StreamServer:
     async def push_emotion(self, payload: Dict[str, float]) -> None:
         message = json.dumps(payload)
         await self.emotion_broadcast.broadcast(message.encode("utf-8"))
+
+    def _emit_audio_client_count(self) -> None:
+        if self._on_audio_client_count_changed:
+            try:
+                self._on_audio_client_count_changed(self._audio_client_count)
+            except Exception:  # pragma: no cover - defensive logging
+                logger.exception("Audio client count callback failed")
+
+    def _emit_emotion_client_count(self) -> None:
+        if self._on_emotion_client_count_changed:
+            try:
+                self._on_emotion_client_count_changed(self._emotion_client_count)
+            except Exception:  # pragma: no cover - defensive logging
+                logger.exception("Emotion client count callback failed")
 
 
 async def serve(app: FastAPI, host: str, port: int) -> None:

--- a/Utils/orchestrator.py
+++ b/Utils/orchestrator.py
@@ -5,7 +5,7 @@ import asyncio
 import contextlib
 import logging
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Protocol
 
 from LLM.engine import LLMConfig, LLMEngine
 from Server.streaming import StreamConfig, StreamServer, serve
@@ -22,21 +22,45 @@ class OrchestratorConfig:
     stream: StreamConfig = field(default_factory=StreamConfig)
 
 
+class OrchestratorEventSink(Protocol):
+    def audio_client_count_changed(self, count: int) -> None:
+        ...
+
+    def emotion_client_count_changed(self, count: int) -> None:
+        ...
+
+
+class TTSInitializationError(RuntimeError):
+    """Raised when the TTS engine fails to initialize."""
+
+
 class VoiceAgentOrchestrator:
     """Glue object binding all sub systems together."""
 
-    def __init__(self, config: OrchestratorConfig):
+    def __init__(
+        self,
+        config: OrchestratorConfig,
+        event_sink: Optional[OrchestratorEventSink] = None,
+    ):
         self.config = config
         self.llm = LLMEngine(config.llm)
         self.tts = KaniTTSEngine(config.tts)
-        self.stream_server = StreamServer(config.stream)
+        self.event_sink = event_sink
+        self.stream_server = StreamServer(
+            config.stream,
+            on_audio_client_count_changed=self._handle_audio_client_count,
+            on_emotion_client_count_changed=self._handle_emotion_client_count,
+        )
         self._emotion_mapper = EmotionMapper()
         self._server_task: Optional[asyncio.Task] = None
 
     async def start(self) -> None:
         logger.info("Starting orchestrator")
         self.llm.load()
-        await self.tts.load()
+        try:
+            await self.tts.load()
+        except Exception as exc:
+            raise TTSInitializationError(str(exc)) from exc
         self._server_task = asyncio.create_task(
             serve(self.stream_server.app, self.config.stream.host, self.config.stream.port)
         )
@@ -72,3 +96,14 @@ class VoiceAgentOrchestrator:
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
         await self.stop()
+
+    # Internal callbacks -------------------------------------------------
+    def _handle_audio_client_count(self, count: int) -> None:
+        logger.info("Audio client count changed: %s", count)
+        if self.event_sink:
+            self.event_sink.audio_client_count_changed(count)
+
+    def _handle_emotion_client_count(self, count: int) -> None:
+        logger.info("Emotion client count changed: %s", count)
+        if self.event_sink:
+            self.event_sink.emotion_client_count_changed(count)


### PR DESCRIPTION
## Summary
- emit audio and emotion WebSocket connection counts from the stream server via the orchestrator
- propagate connection events to the Qt control panel to update the status label and activity log
- surface TTS initialization failures with guidance to run the smoketest script when startup fails

## Testing
- python -m compileall Interface Server Utils

------
https://chatgpt.com/codex/tasks/task_e_68e49fa842ac832fb749a60101a55c37