### PR TITLE
Add Windows stub for nemo_text_processing dependency

### DIFF
--- a/TTS/kani_engine.py
+++ b/TTS/kani_engine.py
@@ -2,8 +2,16 @@
 from __future__ import annotations
 
 import logging
+import os
+import sys
 from pathlib import Path
 from typing import AsyncIterator, Optional
+
+if os.name == "nt":
+    stub_path = os.path.join(os.getcwd(), "stubs")
+    if os.path.isdir(stub_path):
+        sys.path.insert(0, stub_path)
+        print(f"[INFO] Added stub path: {stub_path}")
 
 import numpy as np
 

--- a/stubs/nemo_text_processing/__init__.py
+++ b/stubs/nemo_text_processing/__init__.py
@@ -1,0 +1,8 @@
+print("[INFO] Using stubbed nemo_text_processing (pynini disabled).")
+
+class Normalizer:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def normalize(self, text, **kwargs):
+        return text


### PR DESCRIPTION
## Summary
- add a lightweight nemo_text_processing stub that bypasses pynini on Windows
- inject the stub path when running the Kani TTS engine on Windows hosts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4a9f7f670832f82c5c911b77a60da